### PR TITLE
Remove "sudo" from brew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ EXAMPLE:
 	
 	Before you run this script, please check whether you had install ImageMagick. If you don't have install. Follow this:
 	<pre>
-	sudo brew install ImageMagick</pre>
+	brew install ImageMagick</pre>
 
 2. Clone And Chmod
 	<pre>


### PR DESCRIPTION
Sudo is only used with brew when brew is owned by root, which is recommended against.

See here: https://github.com/Homebrew/legacy-homebrew/issues/9953
