### PR TITLE
Remove ImageMagick Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ios-icon-generator is a shell script which aim to generate iOS APP icons easier and simply.
 ![image](https://github.com/smallmuou/ios-icon-generator/blob/master/ios-icon-generator.gif)
 <pre>
-VERSION: 1.0.0
+VERSION: 1.1.0
 USAGE:
     ./ios-icon-generator.sh srcfile dstpath
 
@@ -13,9 +13,6 @@ DESCRIPTION:
 
     srcfile - The source png image. Preferably above 1024x1024
     dstpath - The destination path where the icons generate to.
-
-    This script is depend on ImageMagick. So you must install ImageMagick first
-    You can use 'sudo brew install ImageMagick' to install it
 
 AUTHOR:
     Pawpaw<lvyexuwenfa100@126.com>
@@ -29,15 +26,7 @@ EXAMPLE:
 </pre>
 
 ### Usage
-1. Install ImageMagick
-	
-	Before you run this script, please check whether you had install ImageMagick. If you don't have install. Follow this:
-
-```bash
-sudo brew install ImageMagick
-```	
-
-2. Clone And Chmod
+1. Clone And Chmod
 
 ```bash
 git clone https://github.com/smallmuou/ios-icon-generator
@@ -45,8 +34,8 @@ cd ios-icon-generator
 chmod 777 ios-icon-generator.sh
 ```
 
-3. Run
-	
+1. Run
+
 ```bash
 StarnetdeMacBook-Pro:ios-icon-generator starnet$ ./ios-icon-generator.sh ~/Downloads/1024.png ~/output
 [INFO] Generate iTunesArtwork.png ...
@@ -85,8 +74,11 @@ Use it in this way `./ios-custom-icon-generator.sh icon-big.png ~/asset_dir 100`
 ### Refer
 * [App Icons on iPad and iPhone](https://developer.apple.com/library/ios/qa/qa1686/_index.html)
 * [iOS Human Interface Guidelines](https://developer.apple.com/library/prerelease/ios/documentation/UserExperience/Conceptual/MobileHIG/IconMatrix.html#//apple_ref/doc/uid/TP40006556-CH27-SW1)
-	
+
 ### History
+* 1.1.0
+	* Removed ImageMagick dependency. Will run on stock installs of macOS.
+
 * 1.0.0
 	* Generate all size icons for iPhone and iPad.
 

--- a/ios-custom-icon-generator.sh
+++ b/ios-custom-icon-generator.sh
@@ -29,7 +29,7 @@ SRC_FILE="$1"
 DST_PATH="$2"
 SIZE="$3"
 
-VERSION=1.0.0
+VERSION=1.1.0
 
 info() {
      local green="\033[1;32m"

--- a/ios-custom-icon-generator.sh
+++ b/ios-custom-icon-generator.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 #
 # Copyright (C) 2015 Alessandro Miliucci<lifeisfoo@gmail.com>
-# 
+#
 # Based on https://github.com/smallmuou/ios-icon-generator/blob/master/ios-icon-generator.sh
 # from Wenva <lvyexuwenfa100@126.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is furnished
 # to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -56,9 +56,6 @@ DESCRIPTION:
     dstpath - The destination path where the icons generate to.
     size - The destination size in pixel, only one number (e.g 60)
 
-    This script is depend on ImageMagick. So you must install ImageMagick first
-    You can use 'sudo brew install ImageMagick' to install it
-
 AUTHOR:
     Alessandro Miliucci<lifeisfoo@gmail.com>
 
@@ -69,9 +66,6 @@ EXAMPLE:
     $0 icon-big.png ~/asset_dir 100
 EOF
 }
-
-# Check ImageMagick
-command -v convert >/dev/null 2>&1 || { error >&2 "The ImageMagick is not installed. Please use brew to install it first."; exit -1; }
 
 # Check param
 if [ $# != 3 ];then
@@ -92,12 +86,12 @@ FILENAME="${FILENAME%.*}"
 OUT_FILENAME="$FILENAME.png"
 
 info "Generate $FILENAME.png ..."
-convert "$SRC_FILE" -resize "$SIZE"x"$SIZE" "$DST_PATH/$FILENAME.png"
+sips "$SRC_FILE" -Z $SIZE --out "$DST_PATH/$FILENAME.png"
 info "Generate $FILENAME@2x.png ..."
 DOUBLE_SIZE=$(($SIZE * 2))
-convert "$SRC_FILE" -resize "$DOUBLE_SIZE"x"$DOUBLE_SIZE" "$DST_PATH/$FILENAME@2x.png"
+sips "$SRC_FILE" -Z $DOUBLE_SIZE --out "$DST_PATH/$FILENAME@2x.png"
 TRIPLE_SIZE=$(($SIZE * 3))
 info "Generate $FILENAME@3x.png ..."
-convert "$SRC_FILE" -resize "$TRIPLE_SIZE"x"$TRIPLE_SIZE" "$DST_PATH/$FILENAME@3x.png"
+sips "$SRC_FILE" -Z $TRIPLE_SIZE --out "$DST_PATH/$FILENAME@3x.png"
 
 info 'Generate Done.'

--- a/ios-icon-generator.sh
+++ b/ios-icon-generator.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 #
 # Copyright (C) 2014 Wenva <lvyexuwenfa100@126.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is furnished
 # to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -51,9 +51,6 @@ DESCRIPTION:
     srcfile - The source png image. Preferably above 1024x1024
     dstpath - The destination path where the icons generate to.
 
-    This script is depend on ImageMagick. So you must install ImageMagick first
-    You can use 'sudo brew install ImageMagick' to install it
-
 AUTHOR:
     Pawpaw<lvyexuwenfa100@126.com>
 
@@ -64,9 +61,6 @@ EXAMPLE:
     $0 1024.png ~/123
 EOF
 }
-
-# Check ImageMagick
-command -v convert >/dev/null 2>&1 || { error >&2 "The ImageMagick is not installed. Please use brew to install it first."; exit -1; }
 
 # Check param
 if [ $# != 2 ];then
@@ -82,59 +76,59 @@ fi
 # Generate, refer to:https://developer.apple.com/library/ios/qa/qa1686/_index.html
 
 info 'Generate iTunesArtwork.png ...'
-convert "$SRC_FILE" -resize 512x512 "$DST_PATH/iTunesArtwork.png"
+sips "$SRC_FILE" -Z 512 --out "$DST_PATH/iTunesArtwork.png"
 info 'Generate iTunesArtwork@2x.png ...'
-convert "$SRC_FILE" -resize 1024x1024 "$DST_PATH/iTunesArtwork@2x.png"
+sips "$SRC_FILE" -Z 1024 --out "$DST_PATH/iTunesArtwork@2x.png"
 
 info 'Generate Icon-20.png ...'
-convert "$SRC_FILE" -resize 20x20 "$DST_PATH/Icon-20.png"
+sips "$SRC_FILE" -Z 20 --out "$DST_PATH/Icon-20.png"
 info 'Generate Icon-20@2x.png ...'
-convert "$SRC_FILE" -resize 40x40 "$DST_PATH/Icon-20@2x.png"
+sips "$SRC_FILE" -Z 40 --out "$DST_PATH/Icon-20@2x.png"
 info 'Generate Icon-40@2x.png ...'
-convert "$SRC_FILE" -resize 60x60 "$DST_PATH/Icon-20@3x.png"
+sips "$SRC_FILE" -Z 60 --out "$DST_PATH/Icon-20@3x.png"
 
 info 'Generate Icon-29.png ...'
-convert "$SRC_FILE" -resize 29x29 "$DST_PATH/Icon-29.png"
+sips "$SRC_FILE" -Z 29 --out "$DST_PATH/Icon-29.png"
 info 'Generate Icon-29@2x.png ...'
-convert "$SRC_FILE" -resize 58x58 "$DST_PATH/Icon-29@2x.png"
+sips "$SRC_FILE" -Z 58 --out "$DST_PATH/Icon-29@2x.png"
 info 'Generate Icon-29@3x.png ...'
-convert "$SRC_FILE" -resize 87x87 "$DST_PATH/Icon-29@3x.png"
+sips "$SRC_FILE" -Z 87 --out "$DST_PATH/Icon-29@3x.png"
 
 info 'Generate Icon-40.png ...'
-convert "$SRC_FILE" -resize 40x40 "$DST_PATH/Icon-40.png"
+sips "$SRC_FILE" -Z 40 --out "$DST_PATH/Icon-40.png"
 info 'Generate Icon-40@2x.png ...'
-convert "$SRC_FILE" -resize 80x80 "$DST_PATH/Icon-40@2x.png"
+sips "$SRC_FILE" -Z 80 --out "$DST_PATH/Icon-40@2x.png"
 info 'Generate Icon-40@3x.png ...'
-convert "$SRC_FILE" -resize 120x120 "$DST_PATH/Icon-40@3x.png"
+sips "$SRC_FILE" -Z 120 --out "$DST_PATH/Icon-40@3x.png"
 
 info 'Generate Icon-60.png ...'
-convert "$SRC_FILE" -resize 60x60 "$DST_PATH/Icon-60.png"
+sips "$SRC_FILE" -Z 60 --out "$DST_PATH/Icon-60.png"
 info 'Generate Icon-60@2x.png ...'
-convert "$SRC_FILE" -resize 120x120 "$DST_PATH/Icon-60@2x.png"
+sips "$SRC_FILE" -Z 120 --out "$DST_PATH/Icon-60@2x.png"
 info 'Generate Icon-60@3x.png ...'
-convert "$SRC_FILE" -resize 180x180 "$DST_PATH/Icon-60@3x.png"
+sips "$SRC_FILE" -Z 180 --out "$DST_PATH/Icon-60@3x.png"
 
 info 'Generate Icon-76.png ...'
-convert "$SRC_FILE" -resize 76x76 "$DST_PATH/Icon-76.png"
+sips "$SRC_FILE" -Z 76 --out "$DST_PATH/Icon-76.png"
 info 'Generate Icon-76@2x.png ...'
-convert "$SRC_FILE" -resize 152x152 "$DST_PATH/Icon-76@2x.png"
+sips "$SRC_FILE" -Z 152 --out "$DST_PATH/Icon-76@2x.png"
 
 info 'Generate Icon-57.png ...'
-convert "$SRC_FILE" -resize 57x57 "$DST_PATH/Icon-57.png"
+sips "$SRC_FILE" -Z 57 --out "$DST_PATH/Icon-57.png"
 info 'Generate Icon-57@2x.png ...'
-convert "$SRC_FILE" -resize 114x114 "$DST_PATH/Icon-57@2x.png"
+sips "$SRC_FILE" -Z 114 --out "$DST_PATH/Icon-57@2x.png"
 
 info 'Generate Icon-83.5@2x.png ...'
-convert "$SRC_FILE" -resize 167x167 "$DST_PATH/Icon-83.5@2x.png"
+sips "$SRC_FILE" -Z 167 --out "$DST_PATH/Icon-83.5@2x.png"
 
 info 'Generate Icon-72.png ...'
-convert "$SRC_FILE" -resize 72x72 "$DST_PATH/Icon-72.png"
+sips "$SRC_FILE" -Z 72 --out "$DST_PATH/Icon-72.png"
 info 'Generate Icon-72@2x.png ...'
-convert "$SRC_FILE" -resize 144x144 "$DST_PATH/Icon-72@2x.png"
+sips "$SRC_FILE" -Z 144 --out "$DST_PATH/Icon-72@2x.png"
 
 info 'Generate Icon-50.png ...'
-convert "$SRC_FILE" -resize 50x50 "$DST_PATH/Icon-50.png"
+sips "$SRC_FILE" -Z 50 --out "$DST_PATH/Icon-50.png"
 info 'Generate Icon-50@2x.png ...'
-convert "$SRC_FILE" -resize 100x100 "$DST_PATH/Icon-50@2x.png"
+sips "$SRC_FILE" -Z 100 --out "$DST_PATH/Icon-50@2x.png"
 
 info 'Generate Done.'

--- a/ios-icon-generator.sh
+++ b/ios-icon-generator.sh
@@ -25,7 +25,7 @@ set -e
 SRC_FILE="$1"
 DST_PATH="$2"
 
-VERSION=1.0.0
+VERSION=1.1.0
 
 info() {
      local green="\033[1;32m"

--- a/ios-navbar-icon-generator.sh
+++ b/ios-navbar-icon-generator.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 #
 # Copyright (C) 2015 Alessandro Miliucci<lifeisfoo@gmail.com>
-# 
+#
 # Based on https://github.com/smallmuou/ios-icon-generator/blob/master/ios-icon-generator.sh
 # from Wenva <lvyexuwenfa100@126.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is furnished
 # to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -54,9 +54,6 @@ DESCRIPTION:
     srcfile - The source png image. Preferably above 66x66
     dstpath - The destination path where the icons generate to.
 
-    This script is depend on ImageMagick. So you must install ImageMagick first
-    You can use 'sudo brew install ImageMagick' to install it
-
 AUTHOR:
     Alessandro Miliucci<lifeisfoo@gmail.com>
 
@@ -67,9 +64,6 @@ EXAMPLE:
     $0 icon-big.png ~/asset_dir
 EOF
 }
-
-# Check ImageMagick
-command -v convert >/dev/null 2>&1 || { error >&2 "The ImageMagick is not installed. Please use brew to install it first."; exit -1; }
 
 # Check param
 if [ $# != 2 ];then
@@ -90,10 +84,10 @@ FILENAME="${FILENAME%.*}"
 OUT_FILENAME="$FILENAME.png"
 
 info "Generate $FILENAME.png ..."
-convert "$SRC_FILE" -resize 22x22 "$DST_PATH/$FILENAME.png"
+sips "$SRC_FILE" -Z 22 --out "$DST_PATH/$FILENAME.png"
 info "Generate $FILENAME@2x.png ..."
-convert "$SRC_FILE" -resize 44x44 "$DST_PATH/$FILENAME@2x.png"
+sips "$SRC_FILE" -Z 44 --out "$DST_PATH/$FILENAME@2x.png"
 info "Generate $FILENAME@3x.png ..."
-convert "$SRC_FILE" -resize 66x66 "$DST_PATH/$FILENAME@3x.png"
+sips "$SRC_FILE" -Z 66 --out "$DST_PATH/$FILENAME@3x.png"
 
 info 'Generate Done.'

--- a/ios-navbar-icon-generator.sh
+++ b/ios-navbar-icon-generator.sh
@@ -28,7 +28,7 @@ set -e
 SRC_FILE="$1"
 DST_PATH="$2"
 
-VERSION=1.0.0
+VERSION=1.1.0
 
 info() {
      local green="\033[1;32m"


### PR DESCRIPTION
I've made an adjustment to remove the dependency on ImageMagick and instead leverage `sips` (built into macOS since very early versions).