### PR TITLE
Add option to specify filename prefix

### DIFF
--- a/ios-icon-generator.sh
+++ b/ios-icon-generator.sh
@@ -104,16 +104,23 @@ DESCRIPTION:
 
 OPTIONS:
     -h      Show this help message and exit
+    -p      Set filename prefix (defaults to "Icon-")
 
 EXAMPLES:
     $prog 1024.png ~/123
+    $prog -p Icon-App- 1024.png ~/123
 
 EOF
 exit 1
 }
 
-while getopts 'h' arg; do
+prefix="Icon-"
+
+while getopts 'hp:' arg; do
     case $arg in
+        p)
+            prefix=$OPTARG
+            ;;
         h)
             usage
             ;;
@@ -159,38 +166,38 @@ fi
 # 
 # name size
 sizes_mapper=`cat << EOF
-Icon-16         16
-Icon-16@2x      32
-Icon-32         32
-Icon-32@2x      64
-Icon-128        128
-Icon-128@2x     256
-Icon-256        256
-Icon-256@2x     256
-Icon-512        512
-Icon-512@2x     1024
-Icon-20         20
-Icon-20@2x      40
-Icon-20@3x      60
-Icon-29         29
-Icon-29@2x      58
-Icon-29@3x      87
-Icon-40         40
-Icon-40@2x      80
-Icon-40@3x      120
-Icon-60@2x      120
-Icon-60@3x      180
-Icon-76         76
-Icon-76@2x      152
-Icon-83.5@2x    167
-Icon-1024       1024
-Icon-24@2x      48
-Icon-27.5@2x    55
-Icon-86@2x      172
-Icon-98@2x      196
-Icon-108@2x     216
-Icon-44@2x      88
-Icon-50@2x      100
+${prefix}16         16
+${prefix}16@2x      32
+${prefix}32         32
+${prefix}32@2x      64
+${prefix}128        128
+${prefix}128@2x     256
+${prefix}256        256
+${prefix}256@2x     256
+${prefix}512        512
+${prefix}512@2x     1024
+${prefix}20         20
+${prefix}20@2x      40
+${prefix}20@3x      60
+${prefix}29         29
+${prefix}29@2x      58
+${prefix}29@3x      87
+${prefix}40         40
+${prefix}40@2x      80
+${prefix}40@3x      120
+${prefix}60@2x      120
+${prefix}60@3x      180
+${prefix}76         76
+${prefix}76@2x      152
+${prefix}83.5@2x    167
+${prefix}1024       1024
+${prefix}24@2x      48
+${prefix}27.5@2x    55
+${prefix}86@2x      172
+${prefix}98@2x      196
+${prefix}108@2x     216
+${prefix}44@2x      88
+${prefix}50@2x      100
 EOF`
 
 OLD_IFS=$IFS

--- a/ios-icon-generator.sh
+++ b/ios-icon-generator.sh
@@ -216,7 +216,7 @@ do
     fi
 done
 
-info "Congratulation. All icons for iOS/macOS/watchOS APP are generate to the directory: $dst_path."
+info "Congratulations. All icons for iOS/macOS/watchOS APP are generate to the directory: $dst_path."
 
 IFS=$OLD_IFS
 


### PR DESCRIPTION
Some environments expect a specific filename format. In the default flutter
setup, for example, icon filenames use the prefix "Icon-App-" instead of
"Icon-".

Add support for specifying a different prefix with the `-p` switch.

This PR also contains a small typo fix.