### PR TITLE
use profile variable instead of the static string

### DIFF
--- a/ios-icon-generator.sh
+++ b/ios-icon-generator.sh
@@ -203,7 +203,7 @@ do
     size=`echo $line|awk '{print $2}'`
     info "Generate $name.png ..."
     if [ -f $srgb_profile ];then
-        sips --matchTo '/System/Library/ColorSync/Profiles/sRGB Profile.icc' -z $size $size $src_file --out $dst_path/$name.png >/dev/null 2>&1
+        sips --matchTo $srgb_profile -z $size $size $src_file --out $dst_path/$name.png >/dev/null 2>&1
     else
         sips -z $size $size $src_file --out $dst_path/$name.png >/dev/null
     fi


### PR DESCRIPTION
Instead of having the same string twice, we now use the already defined variable.